### PR TITLE
Fix an occasional error

### DIFF
--- a/build/bilibili/bilibili-error.js
+++ b/build/bilibili/bilibili-error.js
@@ -23,6 +23,8 @@ var BilibiliError = /** @class */ (function (_super) {
         var _this = _super.apply(this, args) || this;
         _this._code = 'ERR_BILIBILI';
         _this._status = 0;
+        // Set the prototype explicitly (see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work).
+        Object.setPrototypeOf(_this, BilibiliError.prototype);
         return _this;
     }
     BilibiliError.prototype.withStatus = function (s) {

--- a/src/bilibili/bilibili-error.ts
+++ b/src/bilibili/bilibili-error.ts
@@ -3,22 +3,25 @@ export class BilibiliError extends Error {
     private _code:      string;
     private _status:    number;
 
-    constructor(...args: any) {
+    public constructor(...args: any) {
         super(...args);
         this._code = 'ERR_BILIBILI';
         this._status = 0;
+
+        // Set the prototype explicitly (see https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work).
+        Object.setPrototypeOf(this, BilibiliError.prototype);
     }
 
-    withStatus(s: number): BilibiliError {
+    public withStatus(s: number): BilibiliError {
         this._status = s;
         return this;
     }
 
-    get code(): string {
+    public get code(): string {
         return this._code;
     }
 
-    get status(): number {
+    public get status(): number {
         return this._status;
     }
 }


### PR DESCRIPTION
Fix an occasional error that looks like:

 [2020-02-26 09:09:45]   Bilibili.getRoomsInArea - (intermediate value).withStatus is not a function

See https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work