### PR TITLE
Make room collector strategy configurable

### DIFF
--- a/build/app/App.js
+++ b/build/app/App.js
@@ -50,7 +50,7 @@ var App = /** @class */ (function () {
         var _this = this;
         this._appConfig = new index_3.AppConfig();
         this._appConfig.init();
-        this._db = new index_2.Database();
+        this._db = new index_2.Database(this._appConfig.roomCollectorStrategy.roomExpiry);
         this._history = new index_6.History();
         this._emitter = new events_1.EventEmitter();
         this._wsServer = new index_5.WsServer(this._appConfig.wsAddr);
@@ -58,14 +58,14 @@ var App = /** @class */ (function () {
         this._bilihelperServer = new index_5.TCPServerBiliHelper(this._appConfig.bilihelperAddr);
         this._httpServer = new index_5.HttpServer(this._appConfig.httpAddr);
         this._roomCollector = this._appConfig.loadBalancing.totalServers > 1
-            ? new index_6.SimpleLoadBalancingRoomDistributor(this._appConfig.loadBalancing)
-            : new index_6.RoomCollector();
+            ? new index_6.SimpleLoadBalancingRoomDistributor(this._appConfig.loadBalancing, this._appConfig.roomCollectorStrategy)
+            : new index_6.RoomCollector(this._appConfig.roomCollectorStrategy);
         this._fixedController = new index_6.FixedGuardController();
         this._raffleController = new index_6.RaffleController(this._roomCollector);
         this._dynamicController = new index_6.DynamicGuardController();
         this._dynamicRefreshTask = new index_4.DelayedTask();
         this._running = false;
-        this._dynamicRefreshTask.withTime(120 * 1000).withCallback(function () {
+        this._dynamicRefreshTask.withTime(this._appConfig.roomCollectorStrategy.dynamicRoomsQueryInterval * 1000).withCallback(function () {
             var dynamicTask = _this._roomCollector.getDynamicRooms();
             (function () { return __awaiter(_this, void 0, void 0, function () {
                 var roomids, establishedFix_1, establishedDyn_1, newIds, error_1;

--- a/build/bilibili/bilibili.js
+++ b/build/bilibili/bilibili.js
@@ -687,9 +687,10 @@ var Bilibili = /** @class */ (function (_super) {
      * @param   {Integer}   count
      * @returns {Promise}   resolve([ { 'roomid': roomid, 'online': online }, ... ])
      */
-    Bilibili.getRoomsInArea = function (areaid, size, count) {
+    Bilibili.getRoomsInArea = function (areaid, size, count, sortType) {
         if (size === void 0) { size = 99; }
         if (count === void 0) { count = Infinity; }
+        if (sortType === void 0) { sortType = 'live_time'; }
         var page_size = size > 99 || size < 0 ? 99 : size;
         var promises = [];
         var promise = Bilibili.getLiveCount().catch(function (error) {
@@ -697,13 +698,13 @@ var Bilibili = /** @class */ (function (_super) {
             return Promise.resolve(5000); // on error return 5000
         }).then(function (room_count) {
             room_count = Math.min(count, room_count);
-            var PAGES = Math.round(room_count / page_size) + 2;
-            for (var i = 1; i < PAGES; ++i) {
+            var PAGES = Math.ceil(room_count / page_size) + (count === Infinity ? 1 : 0); // If querying all rooms, add one page to query
+            for (var i = 1; i <= PAGES; ++i) {
                 var params = {
                     'parent_area_id': areaid,
                     'page': i,
                     'page_size': page_size,
-                    'sort_type': 'live_time',
+                    'sort_type': sortType,
                 };
                 var request = (index_2.RequestBuilder.start()
                     .withHost('api.live.bilibili.com')

--- a/build/danmu/room-collector.js
+++ b/build/danmu/room-collector.js
@@ -18,8 +18,9 @@ var index_1 = require("../db/index");
 var index_2 = require("../bilibili/index");
 var index_3 = require("../fmt/index");
 var RoomCollector = /** @class */ (function () {
-    function RoomCollector() {
-        this._db = new index_1.Database();
+    function RoomCollector(strategy) {
+        this._db = new index_1.Database(strategy.roomExpiry);
+        this._strategy = strategy;
     }
     RoomCollector.prototype.getFixedRooms = function () {
         var _this = this;
@@ -40,9 +41,13 @@ var RoomCollector = /** @class */ (function () {
             return new Set(_this.filterRooms((_a = []).concat.apply(_a, results)));
         });
     };
-    RoomCollector.prototype.getDynamicRooms = function () {
+    RoomCollector.prototype.getDynamicRooms = function (numDynamicRooms) {
         var _this = this;
-        var task = (index_2.Bilibili.getRoomsInArea(0)
+        if (numDynamicRooms === void 0) { numDynamicRooms = 0; }
+        if (numDynamicRooms === 0) {
+            numDynamicRooms = Infinity;
+        }
+        var task = (index_2.Bilibili.getRoomsInArea(0, this._strategy.dynamicRoomsPageSize, numDynamicRooms, this._strategy.dynamicRoomsSortType)
             .then(function (resp) {
             return _this.filterRooms(resp.map(function (entry) { return entry['roomid']; }));
         })
@@ -72,8 +77,8 @@ var RoomCollector = /** @class */ (function () {
 exports.RoomCollector = RoomCollector;
 var SimpleLoadBalancingRoomDistributor = /** @class */ (function (_super) {
     __extends(SimpleLoadBalancingRoomDistributor, _super);
-    function SimpleLoadBalancingRoomDistributor(loadBalancing) {
-        var _this = _super.call(this) || this;
+    function SimpleLoadBalancingRoomDistributor(loadBalancing, strategy) {
+        var _this = _super.call(this, strategy) || this;
         _this._loadBalancing = loadBalancing;
         return _this;
     }

--- a/build/danmu/tcp-danmu.js
+++ b/build/danmu/tcp-danmu.js
@@ -149,7 +149,7 @@ var AbstractDanmuTCP = /** @class */ (function (_super) {
             this.start();
         }
         else {
-            this.emit('close');
+            this.emit('close', this);
         }
     };
     AbstractDanmuTCP.prototype.onData = function (data) {

--- a/build/db/database.js
+++ b/build/db/database.js
@@ -6,13 +6,14 @@ var chalk = require("chalk");
 var index_1 = require("../task/index");
 var index_2 = require("../fmt/index");
 var Database = /** @class */ (function () {
-    function Database(name) {
+    function Database(expiry, name) {
         var _this = this;
         if (typeof name === 'undefined') {
             name = 'record.json';
         }
         this._filename = path.resolve(__dirname, name);
         this._roomData = {};
+        this._expiry = 1000 * 60 * 60 * 24 * expiry; // expiry is in days
         this._saveTask = new index_1.DelayedTask();
         this._saveTask.withTime(2 * 60 * 1000).withCallback(function () {
             (_this.load()
@@ -87,7 +88,7 @@ var Database = /** @class */ (function () {
         });
     };
     Database.prototype.filter = function (data) {
-        var threshold = new Date().valueOf() - 1000 * 60 * 60 * 24 * 30;
+        var threshold = new Date().valueOf() - this._expiry;
         var result = Object.assign(new Object(), data);
         Object.entries(result).forEach(function (entry) {
             if (entry[1].updated_at < threshold) {

--- a/build/global/config.js
+++ b/build/global/config.js
@@ -18,6 +18,7 @@ var AppConfig = /** @class */ (function () {
         this._biliveAddr = settings['bilive-ws-server'];
         this._bilihelperAddr = settings['bilihelper-tcp-server'];
         this._loadBalancing = settings['load-balancing'];
+        this._roomCollectorStrategy = settings['room-collector-strategy'];
     }
     AppConfig.prototype.init = function () {
         if (this._initialized === false) {
@@ -75,6 +76,13 @@ var AppConfig = /** @class */ (function () {
     Object.defineProperty(AppConfig.prototype, "loadBalancing", {
         get: function () {
             return this._loadBalancing;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(AppConfig.prototype, "roomCollectorStrategy", {
+        get: function () {
+            return this._roomCollectorStrategy;
         },
         enumerable: true,
         configurable: true

--- a/build/net/xhr.js
+++ b/build/net/xhr.js
@@ -23,9 +23,12 @@ var Xhr = /** @class */ (function () {
         var sendRequest = function () {
             var promise = new Promise(function (resolve, reject) {
                 var req = (xhr.request(options)
-                    .on('timeout', function () { return req.abort(); })
+                    .on('timeout', function () {
+                    req.abort();
+                    reject(new index_1.HttpError('Http request timed out'));
+                })
                     .on('abort', function () { return reject(new index_1.HttpError('Http request aborted')); })
-                    .on('error', function () { return reject(new index_1.HttpError('Http request errored')); })
+                    .on('error', function (error) { return reject(new index_1.HttpError("Http request errored - " + error.message)); })
                     .on('close', function () { return reject(new index_1.HttpError('Http request closed')); })
                     .on('response', function (response) {
                     var code = response.statusCode || 0;

--- a/build/settings.json
+++ b/build/settings.json
@@ -22,5 +22,11 @@
     "load-balancing": {
         "totalServers": 1,
         "serverIndex": 0
+    },
+    "room-collector-strategy": {
+        "roomExpiry": 30,
+        "dynamicRoomsQueryInterval": 120,
+        "dynamicRoomsPageSize": 99,
+        "dynamicRoomsSortType": "live_time"
     }
 }

--- a/docs/before-starting/README.md
+++ b/docs/before-starting/README.md
@@ -42,6 +42,16 @@
 }
 ```
 
+### 房间收集策略
+```javascript
+    "room-collector-strategy": {
+        "roomExpiry": 30,                     // 非活跃房间在数据库中的保存天数
+        "dynamicRoomsQueryInterval": 120,     // 查询动态房间列表间隔，单位为秒
+        "dynamicRoomsPageSize": 99,           // 查询动态房间列表时每页房间数。数值越大则总请求数越少，但每个请求传输时间及超时可能变大
+        "dynamicRoomsSortType": "live_time"   // 查询动态房间列表时排序方法。live_time是房间在线时间。online是人气值
+    }
+```
+
 ### 负载均衡
 如果需要使用多个服务器来均衡负载，可以修改load-balancing设置。totalServers是服务器总数，serverIndex是本服务器序号，在0与totalServers减1之间。每个服务器需使用不同序号。
 需要说明的是，负载并不是完全均衡。实现方式是取房间号对于服务器总数的余数，所以每个服务器监听的房间数目会有一定出入，但相差不会很多。每个服务器监听的房间并不会重复。

--- a/src/bilibili/bilibili-error.ts
+++ b/src/bilibili/bilibili-error.ts
@@ -12,7 +12,7 @@ export class BilibiliError extends Error {
         Object.setPrototypeOf(this, BilibiliError.prototype);
     }
 
-    public withStatus(s: number): BilibiliError {
+    public withStatus(s: number): this {
         this._status = s;
         return this;
     }

--- a/src/bilibili/bilibili.ts
+++ b/src/bilibili/bilibili.ts
@@ -816,7 +816,7 @@ export class Bilibili extends BilibiliBase {
      * @param   {Integer}   count
      * @returns {Promise}   resolve([ { 'roomid': roomid, 'online': online }, ... ])
      */
-    static getRoomsInArea(areaid: number, size: number=99, count: number=Infinity): Promise<any> {
+    static getRoomsInArea(areaid: number, size: number=99, count: number=Infinity, sortType='live_time'): Promise<any> {
         const page_size = size > 99 || size < 0 ? 99 : size;
 
         let promises: Promise<any>[] = [];
@@ -829,14 +829,14 @@ export class Bilibili extends BilibiliBase {
         }).then((room_count: number): Promise<any> => {
 
             room_count = Math.min(count, room_count);
-            const PAGES: number = Math.round(room_count / page_size) + 2;
+            const PAGES: number = Math.ceil(room_count / page_size) + (count === Infinity ? 1 : 0); // If querying all rooms, add one page to query
 
-            for (let i = 1; i < PAGES; ++i) {
+            for (let i = 1; i <= PAGES; ++i) {
                 const params: any = {
                     'parent_area_id': areaid, 
                     'page': i, 
                     'page_size': page_size, 
-                    'sort_type': 'live_time',
+                    'sort_type': sortType,
                 };
 
                 const request: Request = (RequestBuilder.start()

--- a/src/danmu/tcp-danmu.ts
+++ b/src/danmu/tcp-danmu.ts
@@ -175,7 +175,7 @@ export abstract class AbstractDanmuTCP extends EventEmitter implements Startable
             this.start();
         }
         else {
-            this.emit('close');
+            this.emit('close', this);
         }
     }
 

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -17,14 +17,16 @@ export class Database {
 
     private _filename:  string;
     private _roomData:  RoomData;
+    private _expiry:    number;
     private _saveTask:  DelayedTask;
 
-    constructor(name?: string) {
+    constructor(expiry: number, name?: string) {
         if (typeof name === 'undefined') {
             name = 'record.json';
         }
         this._filename = path.resolve(__dirname, name);
         this._roomData = {};
+        this._expiry = 1000 * 60 * 60 * 24 * expiry; // expiry is in days
         this._saveTask = new DelayedTask();
         this._saveTask.withTime(2 * 60 * 1000).withCallback((): void => {
             (this.load()
@@ -105,7 +107,7 @@ export class Database {
     }
 
     filter(data: RoomData): RoomData {
-        const threshold: number = new Date().valueOf() - 1000 * 60 * 60 * 24 * 30;
+        const threshold: number = new Date().valueOf() - this._expiry;
         const result: any = Object.assign(new Object(), data);
         Object.entries(result).forEach((entry: any): void => {
             if (entry[1].updated_at < threshold) {

--- a/src/global/config.ts
+++ b/src/global/config.ts
@@ -24,23 +24,31 @@ export interface LoadBalancing {
     readonly serverIndex:   number;
 }
 
+export interface RoomCollectorStrategy {
+    readonly roomExpiry:                number;
+    readonly dynamicRoomsQueryInterval: number;
+    readonly dynamicRoomsPageSize:      number;
+    readonly dynamicRoomsSortType:      string;
+}
+
 export class AppConfig implements AppSettings {
 
-    private _debug:             boolean;
-    private _verbose:           boolean;
-    private _tcp_error:         boolean;
-    private _appkey:            string;
-    private _appSecret:         string;
-    private _appCommon:         {[key: string]: any};
-    private _appHeaders:        {[key: string]: string};
-    private _webHeaders:        {[key: string]: string};
-    private _initialized:       boolean;
-    private _danmuAddr:         TCPAddress;
-    private _wsAddr:            TCPAddress;
-    private _biliveAddr:        TCPAddress;
-    private _bilihelperAddr:    TCPAddress;
-    private _httpAddr:          TCPAddress;
-    private _loadBalancing:     LoadBalancing;
+    private _debug:                     boolean;
+    private _verbose:                   boolean;
+    private _tcp_error:                 boolean;
+    private _appkey:                    string;
+    private _appSecret:                 string;
+    private _appCommon:                 {[key: string]: any};
+    private _appHeaders:                {[key: string]: string};
+    private _webHeaders:                {[key: string]: string};
+    private _initialized:               boolean;
+    private _danmuAddr:                 TCPAddress;
+    private _wsAddr:                    TCPAddress;
+    private _biliveAddr:                TCPAddress;
+    private _bilihelperAddr:            TCPAddress;
+    private _httpAddr:                  TCPAddress;
+    private _loadBalancing:             LoadBalancing;
+    private _roomCollectorStrategy:     RoomCollectorStrategy;
 
     constructor() {
         this._debug = false;
@@ -58,6 +66,7 @@ export class AppConfig implements AppSettings {
         this._biliveAddr = settings['bilive-ws-server'] as TCPAddress;
         this._bilihelperAddr = settings['bilihelper-tcp-server'] as TCPAddress;
         this._loadBalancing = settings['load-balancing'] as LoadBalancing;
+        this._roomCollectorStrategy = settings['room-collector-strategy'] as RoomCollectorStrategy;
     }
 
     init() {
@@ -102,6 +111,10 @@ export class AppConfig implements AppSettings {
 
     get loadBalancing(): LoadBalancing {
         return this._loadBalancing;
+    }
+
+    get roomCollectorStrategy(): RoomCollectorStrategy {
+        return this._roomCollectorStrategy;
     }
 
     get debug(): boolean {

--- a/src/net/xhr.ts
+++ b/src/net/xhr.ts
@@ -43,9 +43,12 @@ export class Xhr implements Sender {
 
             const promise = new Promise<Response>((resolve, reject) => {
                 const req = (xhr.request(options)
-                    .on('timeout', () => req.abort())
+                    .on('timeout', () => {
+                        req.abort();
+                        reject(new HttpError('Http request timed out'));
+                    })
                     .on('abort', () => reject(new HttpError('Http request aborted')))
-                    .on('error', () => reject(new HttpError('Http request errored')))
+                    .on('error', (error: Error) => reject(new HttpError(`Http request errored - ${error.message}`)))
                     .on('close', () => reject(new HttpError('Http request closed')))
                     .on('response', (response: HttpType.IncomingMessage) => {
                         const code: number = response.statusCode || 0;

--- a/src/settings.json
+++ b/src/settings.json
@@ -22,5 +22,11 @@
     "load-balancing": {
         "totalServers": 1,
         "serverIndex": 0
+    },
+    "room-collector-strategy": {
+        "roomExpiry": 30,
+        "dynamicRoomsQueryInterval": 120,
+        "dynamicRoomsPageSize": 99,
+        "dynamicRoomsSortType": "live_time"
     }
 }


### PR DESCRIPTION
Expiry in database; Dynamic rooms query interval, page size and sort type.

Also various changes:

- Improved performance when adding rooms to a monitor by skipping creation of Set which is not needed.
- Made GuardController's listener 'close' handling better in OOP.
- When querying dynamic rooms, only add extra page when querying all rooms.
- Include error message in HTTP error
- Display timeout instead of aborted when HTTP request times out
