### PR TITLE
Change recently closed rooms tracking from array size based to time based

### DIFF
--- a/build/app/App.js
+++ b/build/app/App.js
@@ -154,6 +154,8 @@ var App = /** @class */ (function () {
             this.setupHttp();
             this.startServers();
             this._db.start();
+            this._fixedController.start();
+            this._dynamicController.start();
             this._raffleController.start();
             var fixedTask_1 = this._roomCollector.getFixedRooms();
             var dynamicTask_1 = this._roomCollector.getDynamicRooms();

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -140,6 +140,8 @@ export class App {
             this.setupHttp();
             this.startServers();
             this._db.start();
+            this._fixedController.start();
+            this._dynamicController.start();
             this._raffleController.start();
             const fixedTask = this._roomCollector.getFixedRooms();
             const dynamicTask = this._roomCollector.getDynamicRooms();


### PR DESCRIPTION
[Edit]
As per comment from @Billyzou0741326 below, the handling of recently closed rooms are removed. Other refactoring are still applicable, including the new start() method, which for now is just empty but good for consistency.

--------------------------------------------------------------------------------------------------------
Assuming the reason why recently closed rooms are tracked is that dynamic room query could return rooms that are just closed, using array size to control rooms being tracked could have 2 issues:

1. When very few rooms were closed recently, they will stay in the array for quite a while. If a room comes back online, it will not be added to dynamic list. This may be a coverage concern.
2. When there are many rooms closed in a short time (> 50), some will not be tracked due to array size, and are thus still subject to the original problem this tracking mechanism tried to solve.

This it is now changed to be time based. A closed room will have an expiry (for now, 150 seconds) in the tracking map, and will not be tracked anymore after that (cleanup interval is set as 60 seconds). I am not sure if 150 seconds is a good value. It is chosen only to make sure if a room comes back in the next dynamic room query it will be skipped. You may know a better value as it really depends on the original issue this tracking mechanism addresses.

There are also some refactoring in room controllers:

- add(rooms) & setupRoom(roomid) are concepts of GuardController, and not for RaffleController since it works on area. Therefore these methods are moved down to GuardController. This also enables removing areaid parameter from setupRoom as it doesn't belong to GuardController
- closed rooms tracking is only needed by DynamicGuardController. Although logically RaffleController could be subject to the same mechanism, it is not currently used so I assume it is not really needed.
- added start() to AbstractRoomController for consistency, and also used by DynamicGuardController to kick off the new janitor task.
- renamed setupRoom in RaffleController to setupRoomInArea for consistency and better reflection of its nature. areadid parameter is now required