### PR TITLE
Crawler is blocking all other HTTP requests while it's running

### DIFF
--- a/build/danmu/room-crawler.js
+++ b/build/danmu/room-crawler.js
@@ -53,19 +53,20 @@ var chalk = require("chalk");
 var events_1 = require("events");
 var index_1 = require("../fmt/index");
 var index_2 = require("../bilibili/index");
-var index_3 = require("./index");
-var index_4 = require("../danmu/index");
+var index_3 = require("../task/index");
+var index_4 = require("./index");
+var index_5 = require("../danmu/index");
 var RoomCrawler = /** @class */ (function (_super) {
     __extends(RoomCrawler, _super);
     function RoomCrawler(collector) {
         var _this = _super.call(this) || this;
-        _this.collector_ = collector || new index_3.RoomCollector();
-        _this.roomidHandler_ = new index_3.RoomidHandler();
+        _this.collector_ = collector || new index_4.RoomCollector();
+        _this.roomidHandler_ = new index_4.RoomidHandler().withRateLimiter(new index_3.RateLimiter(40, 1000));
         var _loop_1 = function (cate) {
             this_1.roomidHandler_.on(cate, function (g) { _this.emit(cate, g); });
         };
         var this_1 = this;
-        for (var cate in index_4.RaffleCategory) {
+        for (var cate in index_5.RaffleCategory) {
             _loop_1(cate);
         }
         return _this;

--- a/src/danmu/room-crawler.ts
+++ b/src/danmu/room-crawler.ts
@@ -3,7 +3,9 @@ import { EventEmitter } from 'events';
 import { sleep } from '../async/index';
 import { cprint } from '../fmt/index';
 import { Bilibili } from '../bilibili/index';
-import { DelayedTask } from '../task/index';
+import {
+    DelayedTask,
+    RateLimiter, } from '../task/index';
 import {
     RoomCollector,
     RoomidHandler, } from './index';
@@ -19,7 +21,7 @@ export class RoomCrawler extends EventEmitter {
     constructor(collector?: RoomCollector) {
         super();
         this.collector_ = collector || new RoomCollector();
-        this.roomidHandler_ = new RoomidHandler();
+        this.roomidHandler_ = new RoomidHandler().withRateLimiter(new RateLimiter(40, 1000));
 
         for (const cate in RaffleCategory) {
             this.roomidHandler_.on(cate, (g: Raffle) => { this.emit(cate, g) });


### PR DESCRIPTION
Since all those requests from roomid-handler are filling the queue in  Xhr's RateLimiter so other requests have to wait in the queue for a long time. I added a RateLimiter on roomid-handler to give other clients a chance to sneak in their requests.

Also, in some scenarios rooms with activities are not added to db, so simplified add_to_db handling to purely rely on raffle.

As a side note, I notice that you are using node.js 11+ features, like optional offset in Buffer.writeUInt32BE(), and since @type.node is asking for a version 13.x, maybe you want to update node.js badge to increase the required version?