### PR TITLE
Handle CUT_OFF message

### DIFF
--- a/build/danmu/tcp-danmu.js
+++ b/build/danmu/tcp-danmu.js
@@ -293,8 +293,8 @@ var DanmuTCP = /** @class */ (function (_super) {
             case 'ROOM_CHANGE':
                 this.onRoomChange(msg);
                 break;
-            case 'PREPARING':
-                this.onPreparing(msg);
+            case 'CUT_OFF':
+                this.onCutoff(msg);
                 break;
             case 'LIVE':
                 this.onLive(msg);
@@ -445,6 +445,8 @@ var DanmuTCP = /** @class */ (function (_super) {
     DanmuTCP.prototype.onNoticeMsg = function (msg) {
     };
     DanmuTCP.prototype.onPreparing = function (msg) {
+    };
+    DanmuTCP.prototype.onCutoff = function (msg) {
     };
     DanmuTCP.prototype.onLive = function (msg) {
     };
@@ -619,6 +621,9 @@ var DynamicGuardMonitor = /** @class */ (function (_super) {
     DynamicGuardMonitor.prototype.onPreparing = function (msg) {
         this._canClose = true;
     };
+    DynamicGuardMonitor.prototype.onCutoff = function (msg) {
+        this._canClose = true;
+    };
     DynamicGuardMonitor.prototype.onLive = function (msg) {
         this._canClose = false;
     };
@@ -667,6 +672,11 @@ var RaffleMonitor = /** @class */ (function (_super) {
         }
     };
     RaffleMonitor.prototype.onPreparing = function (msg) {
+        if (this.areaid !== 0) {
+            this.close(true);
+        }
+    };
+    RaffleMonitor.prototype.onCutoff = function (msg) {
         if (this.areaid !== 0) {
             this.close(true);
         }

--- a/src/danmu/tcp-danmu.ts
+++ b/src/danmu/tcp-danmu.ts
@@ -330,8 +330,8 @@ export abstract class DanmuTCP extends AbstractDanmuTCP {
             case 'ROOM_CHANGE':
                 this.onRoomChange(msg);
                 break;
-            case 'PREPARING':
-                this.onPreparing(msg);
+            case 'CUT_OFF':
+                this.onCutoff(msg);
                 break;
             case 'LIVE':
                 this.onLive(msg);
@@ -504,16 +504,19 @@ export abstract class DanmuTCP extends AbstractDanmuTCP {
         return details;
     }
 
-    protected onNoticeMsg(msg: any) {
+    protected onNoticeMsg(msg: any): void {
     }
 
-    protected onPreparing(msg: any) {
+    protected onPreparing(msg: any): void {
     }
 
-    protected onLive(msg: any) {
+    protected onCutoff(msg: any): void {
     }
 
-    protected onRoomChange(msg: any) {
+    protected onLive(msg: any): void {
+    }
+
+    protected onRoomChange(msg: any): void {
     }
 
     protected onPopularity(popularity: number): number {
@@ -706,6 +709,10 @@ export class DynamicGuardMonitor extends FixedGuardMonitor {
         this._canClose = true;
     }
 
+    protected onCutoff(msg: any): void {
+        this._canClose = true;
+    }
+
     protected onLive(msg: any): void {
         this._canClose = false;
     }
@@ -759,6 +766,12 @@ export class RaffleMonitor extends DanmuTCP {
     }
 
     protected onPreparing(msg: any): void {
+        if (this.areaid !== 0) {
+            this.close(true);
+        }
+    }
+
+    protected onCutoff(msg: any): void {
         if (this.areaid !== 0) {
             this.close(true);
         }


### PR DESCRIPTION
This could happen if a room received a WARNING message but didn't act on it or act in time. For example, this log (timestamp in EST):

 [2020-05-01 08:49:00]   DanmuTCP: @21525410 received WARNING
 [2020-05-01 08:49:00]   {"cmd":"WARNING","msg":"违反直播分区规范，请立即更换至映评馆","roomid":21525410}

 [2020-05-01 08:56:39]   DanmuTCP: @21525410 received CUT_OFF

Note that in processMsg, "PREPARING" was checked twice so I just replaced one.